### PR TITLE
Global leak detecion

### DIFF
--- a/lib/gonzales.cssp.node.js
+++ b/lib/gonzales.cssp.node.js
@@ -107,7 +107,7 @@ function getTokens(s) {
 
         tokens = [];
 
-        var c, nc;
+        var c, cn;
 
         for (pos = 0; pos < s.length; pos++) {
             c = s.charAt(pos);


### PR DESCRIPTION
Mocha test framework has accused a global leak detection in gonzales.cssp.node.js, that turns out to be a simple spelling mistake.

By the way, nice job with this.
