### PR TITLE
Do not compress `transition` property

### DIFF
--- a/lib/compressor.js
+++ b/lib/compressor.js
@@ -854,7 +854,7 @@ CSSOCompressor.prototype.compressFunctionColor = function(token) {
 CSSOCompressor.prototype.compressDimension = function(token) {
     var declaration;
     if (token[2][2] === '0') {
-        if (token[3][2] === 's' && (declaration = this.findDeclaration(token))) {
+        if ((token[3][2] === 's' || token[3][2] === 'ms') && (declaration = this.findDeclaration(token))) {
             var declName = declaration[2][2][2];
             if  (declName === '-moz-transition' || declName === 'transition') return; // https://github.com/css/csso/issues/82, also support recent Fx versions
             if  (declName === '-moz-animation' || declName === 'animation') return; // https://github.com/css/csso/issues/100

--- a/test/data/test_stylesheet/issue82.test1.cl
+++ b/test/data/test_stylesheet/issue82.test1.cl
@@ -1,1 +1,1 @@
-.foo{-moz-transition:0s;transition:0}
+.foo{-webkit-transition:0 0;-moz-transition:0s 0ms;transition:0s 0ms}

--- a/test/data/test_stylesheet/issue82.test1.css
+++ b/test/data/test_stylesheet/issue82.test1.css
@@ -1,4 +1,5 @@
 .foo {
-    -moz-transition: 0s;
-    transition: 0s;
+	-webkit-transition: 0s 0ms;
+    -moz-transition: 0s 0ms;
+    transition: 0s 0ms;
 }


### PR DESCRIPTION
A follow-up to #82
Recent Firefox versions are using unprefixed `transition` property
