### PR TITLE
Allow more values after funktion

### DIFF
--- a/lib/compressor.js
+++ b/lib/compressor.js
@@ -741,7 +741,6 @@ CSSOCompressor.prototype._cleanWhitespace = function(r, left) {
     }
     if (left) {
         switch(r) {
-            case 'funktion':
             case 'braces':
             case 'uri':
                 return true;

--- a/test/data/test_stylesheet/issue153.test1.cl
+++ b/test/data/test_stylesheet/issue153.test1.cl
@@ -1,0 +1,1 @@
+a{box-shadow:#fff 0 0 0!important}

--- a/test/data/test_stylesheet/issue153.test1.css
+++ b/test/data/test_stylesheet/issue153.test1.css
@@ -1,0 +1,3 @@
+a {
+    box-shadow: rgb(255, 255, 255) 0px 0px 0px !important;
+}

--- a/test/data/test_stylesheet/issue156.test1.cl
+++ b/test/data/test_stylesheet/issue156.test1.cl
@@ -1,0 +1,1 @@
+a{background:linear-gradient(bottom,#d1d1d1 10%,#fafafa 55%)}

--- a/test/data/test_stylesheet/issue156.test1.css
+++ b/test/data/test_stylesheet/issue156.test1.css
@@ -1,0 +1,3 @@
+a {
+    background: linear-gradient(bottom, rgb(209,209,209) 10%, rgb(250,250,250) 55%);
+}


### PR DESCRIPTION
Don't remove white space after funktion, because new CSS rules sometimes
add more values after a color. For instance box-shadow or linear-gradient.

Fixes #153 and #156
