### PR TITLE
Remove russian symbol from english category names in meta information 

### DIFF
--- a/docs/description/description.ja.meta.json
+++ b/docs/description/description.ja.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["ishimoto-koji"],
     "url": "/docs/description/",
     "type": "tools",

--- a/docs/description/description.ko.meta.json
+++ b/docs/description/description.ko.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["Wankyu"],
     "url": "/docs/description/",
     "type": "tools",

--- a/docs/description/description.ru.meta.json
+++ b/docs/description/description.ru.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Оптимизаторы/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Оптимизаторы/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": [],
     "url": "/docs/description/",
     "type": "tools",

--- a/docs/index/index.en.meta.json
+++ b/docs/index/index.en.meta.json
@@ -6,7 +6,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["khachaturov-leonid"],
     "url": "/docs/index/",
     "type": "tools",

--- a/docs/index/index.ja.meta.json
+++ b/docs/index/index.ja.meta.json
@@ -6,7 +6,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["ishimoto-koji"],
     "url": "/docs/index/",
     "type": "tools",

--- a/docs/index/index.ko.meta.json
+++ b/docs/index/index.ko.meta.json
@@ -6,7 +6,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["Wankyu"],
     "url": "/docs/index/",
     "type": "tools",

--- a/docs/index/index.ru.meta.json
+++ b/docs/index/index.ru.meta.json
@@ -6,7 +6,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Оптимизаторы/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Оптимизаторы/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": [],
     "url": "/docs/index/",
     "type": "tools",

--- a/docs/install/install.en.meta.json
+++ b/docs/install/install.en.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["khachaturov-leonid"],
     "url": "/docs/install/",
     "type": "tools",

--- a/docs/install/install.ja.meta.json
+++ b/docs/install/install.ja.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["ishimoto-koji"],
     "url": "/docs/install/",
     "type": "tools",

--- a/docs/install/install.ko.meta.json
+++ b/docs/install/install.ko.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["Wankyu"],
     "url": "/docs/install/",
     "type": "tools",

--- a/docs/install/install.ru.meta.json
+++ b/docs/install/install.ru.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Оптимизаторы/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Оптимизаторы/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": [],
     "url": "/docs/install/",
     "type": "tools",

--- a/docs/usage/usage.en.meta.json
+++ b/docs/usage/usage.en.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["khachaturov-leonid"],
     "url": "/docs/usage/",
     "type": "tools",

--- a/docs/usage/usage.ja.meta.json
+++ b/docs/usage/usage.ja.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["ishimoto-koji"],
     "url": "/docs/usage/",
     "type": "tools",

--- a/docs/usage/usage.ko.meta.json
+++ b/docs/usage/usage.ko.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Optimizers/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Optimizers/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": ["Wankyu"],
     "url": "/docs/usage/",
     "type": "tools",

--- a/docs/usage/usage.ru.meta.json
+++ b/docs/usage/usage.ru.meta.json
@@ -7,7 +7,7 @@
     "thumbnail": "",
     "authors": ["harisov-vitaly"],
     "tags": ["tools", "css"],
-    "categories": [{"name": "Оптимизаторы/СSSO", "url": "optimizers/csso", "order": "20/20"}],
+    "categories": [{"name": "Оптимизаторы/CSSO", "url": "optimizers/csso", "order": "20/20"}],
     "translators": [],
     "url": "/docs/usage/",
     "type": "tools",


### PR DESCRIPTION
Remove russian symbol from english category names in meta information files. It was error symbol C in CSSO string which was reason of error in build documentation data process.
