### PR TITLE
bugfix issue #159 : Do not merge TRBL values having \9 (hack for IE8)

### DIFF
--- a/lib/compressor.js
+++ b/lib/compressor.js
@@ -116,11 +116,13 @@ TRBL.prototype.add = function(name, sValue, tValue, imp) {
 
 TRBL.prototype.isOkToMinimize = function() {
     var s = this.sides,
-        imp;
+        imp,
+        ieReg = /\\9$/;
 
     if (!!(s.top && s.right && s.bottom && s.left)) {
         imp = s.top.imp + s.right.imp + s.bottom.imp + s.left.imp;
-        return (imp === 0 || imp === 4 || imp === this.imp);
+        ieHack = (ieReg.test(s.top.s) || ieReg.test(s.right.s) || ieReg.test(s.bottom.s) || ieReg.test(s.left.s));
+        return (!ieHack && (imp === 0 || imp === 4 || imp === this.imp));
     }
     return false;
 };


### PR DESCRIPTION
Hi,

I make a quick bugfix for issue #159, by disabling merging when a trbl (padding/margin) property had a values with a `\9`. 

I don't know if it make sense to develop more and handle the `\9` case like the `!important` statement, and merge all values with a '\9' : Like `padding-top:1px\9;padding-right:1px;padding-bottom:1px;padding-left:1px\9;` => `padding:1px\9 ` ?