### PR TITLE
Fix errors in windows

### DIFF
--- a/bin/csso
+++ b/bin/csso
@@ -1,13 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
+'use strict';
 
-SELF_PATH=$(cd -P -- "$(dirname -- "$0")" && pwd -P) && SELF_PATH="$SELF_PATH/$(basename -- "$0")"
-
-while [ -h "$SELF_PATH" ]; do
-    DIR=$(dirname -- "$SELF_PATH")
-    SYM=$(readlink -- "$SELF_PATH")
-    SELF_PATH=$(cd -- "$DIR" && cd -- $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
-done
-
-CSSO_HOME=$(dirname -- "$(dirname -- "$SELF_PATH")")
-
-node "$CSSO_HOME/lib/csso.js" $@
+require(require('path').resolve(__dirname, '../lib/csso.js'));

--- a/lib/csso.js
+++ b/lib/csso.js
@@ -66,5 +66,5 @@ function getOpts(argv, o_single, o_pairs) {
 }
 
 function printFile(filename) {
-    print(fs.readFileSync(__dirname.slice(0, __dirname.lastIndexOf('/')) + '/' + filename).toString());
+    print(fs.readFileSync(__dirname + '/../' + filename).toString());
 }


### PR DESCRIPTION
| Fix files | Description |
|---|---|
| bin/csso   | Fix error that happen because the directory separator is not `/` in windows |
| lib/csso.js | Fix error resulting from mixing `\` & `/` in argument for `_dirname` resolves a faulty path |