### PR TITLE
Remove Byte-order-mark from UTF-8 encoded input

### DIFF
--- a/lib/gonzales.cssp.node.js
+++ b/lib/gonzales.cssp.node.js
@@ -106,6 +106,11 @@ var getTokens = (function() {
     function _getTokens(s) {
         if (!s) return [];
 
+        // Remove BOM from UTF-8 encoded input
+        if (s.charCodeAt(0) === 0xFEFF) {
+            s = s.slice(1);
+        }
+
         tokens = [];
 
         var c, cn;


### PR DESCRIPTION
Good evening,

I found a problem in my build chain while using [webpack/css-loader](https://github.com/webpack/css-loader) (which uses csso). According to [its specification](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#encodings) a sass preprocessor in compression mode creates a UTF-8 encoded file starting with a byte-order-mark. csso is unable to interpret this file because it sees the byte-order-mark as a character. You can test this behavior with the following code:
```javascript
// Hex representation of "@media print"
var bodyNoBOM = "406d65646961207072696e74";
// Hex representation of "@media print" with leading BOM (EF BB BF)
var bodyBOM = "efbbbf406d65646961207072696e74";

// Everything's fine for this code
require("./lib/cssoapi.js").parse(new Buffer(bodyNoBOM, "hex").toString("utf8"));

// This code ...
require("./lib/cssoapi.js").parse(new Buffer(bodyBOM, "hex").toString("utf8"));
// throws this exception:
/*
Error: Please check the validity of the CSS block starting from the line #1
    at throwError (/workspace-github/csso/lib/gonzales.cssp.node.js:399:15)
    at checkStylesheet (/workspace-github/csso/lib/gonzales.cssp.node.js:1921:22)
    at Object.CSSPRules.stylesheet (/workspace-github/csso/lib/gonzales.cssp.node.js:365:40)
    at _getAST (/workspace-github/csso/lib/gonzales.cssp.node.js:409:66)
    at exports.srcToCSSP (/workspace-github/csso/lib/gonzales.cssp.node.js:2287:16)
    at Object.exports.srcToCSSP (/workspace-github/csso/lib/gonzales.cssp.node.js:2292:16)
    at Object.exports.parse (/workspace-github/csso/lib/cssoapi.js:7:21)
    at repl:1:3
    at REPLServer.self.eval (repl.js:110:21)
    at repl.js:249:20
*/
```
This pull request removes the byte-order-mark if it's found. Though technically this is a problem of the input data it could make csso a lot less error-prone when used with CSS preprocessors.

Best regards,
Benjamin