### PR TITLE
Ensure `-` is not used as an identifier

### DIFF
--- a/lib/compressor/compress/Attribute.js
+++ b/lib/compressor/compress/Attribute.js
@@ -5,7 +5,7 @@ var escapesRx = /\\([0-9A-Fa-f]{1,6})[ \t\n\f\r]?|\\./g;
 var blockUnquoteRx = /^(-?\d|--)|[\u0000-\u002c\u002e\u002f\u003A-\u0040\u005B-\u005E\u0060\u007B-\u009f]/;
 
 function canUnquote(value) {
-    if (!value) {
+    if (value === '' || value === '-') {
         return;
     }
 

--- a/test/fixture/compress/attrib.string/1.css
+++ b/test/fixture/compress/attrib.string/1.css
@@ -1,6 +1,7 @@
 [title="test"],
 [title="123"],
 [title="test test"],
+[title="-"],
 [title=""]
 {
     p: v;

--- a/test/fixture/compress/attrib.string/1.min.css
+++ b/test/fixture/compress/attrib.string/1.min.css
@@ -1,1 +1,1 @@
-[title=""],[title="123"],[title="test test"],[title=test]{p:v}
+[title=""],[title="-"],[title="123"],[title="test test"],[title=test]{p:v}

--- a/test/fixture/compress/attrib.string/2.css
+++ b/test/fixture/compress/attrib.string/2.css
@@ -1,6 +1,7 @@
 [title='test'],
 [title='123'],
 [title='test test'],
+[title='-'],
 [title='']
 {
     p: v;

--- a/test/fixture/compress/attrib.string/2.min.css
+++ b/test/fixture/compress/attrib.string/2.min.css
@@ -1,1 +1,1 @@
-[title=''],[title='123'],[title='test test'],[title=test]{p:v}
+[title=''],[title='-'],[title='123'],[title='test test'],[title=test]{p:v}


### PR DESCRIPTION
`-` is not a valid identifier, so it must be either escaped as `\-` or used as a string (i.e. wrapped in quotes).

Ref. c5095ebbf6ea95500fa38427094a137fad9660c0.
Ref. #73.