### PR TITLE
Basic "plugin" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Options:
 - sourceMap `Boolean` - generate source map if `true`
 - filename `String` - filename of input, uses for source map
 - debug `Boolean` - output debug information to `stderr`
+- afterParse `function|array<function>` - called right after parse is run. Callbacks arguments are `ast, options`.
+- afterCompress `function|array<function>` - called right after compress is run. Callbacks arguments are `compressResult, options`.
 - other options are the same as for `compress()`
 
 Returns an object with properties:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Options:
 - sourceMap `Boolean` - generate source map if `true`
 - filename `String` - filename of input, uses for source map
 - debug `Boolean` - output debug information to `stderr`
-- afterParse `function|array<function>` - called right after parse is run. Callbacks arguments are `ast, options`.
+- beforeCompress `function|array<function>` - called right after parse is run. Callbacks arguments are `ast, options`.
 - afterCompress `function|array<function>` - called right after compress is run. Callbacks arguments are `compressResult, options`.
 - other options are the same as for `compress()`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,10 +62,10 @@ function buildCompressOptions(options) {
 
 function runPlugins(ast, options, plugin) {
     var plugins = [];
-    if (Array.isArray(options[plugin])) {
-        plugins = options[plugin];
-    } else if (typeof options[plugin] === 'function') {
-        plugins = [options[plugin]];
+    if (Array.isArray(plugin)) {
+        plugins = plugin;
+    } else if (typeof plugin === 'function') {
+        plugins = [plugin];
     }
     plugins.forEach(function(plugin) {
         plugin(ast, options);
@@ -90,7 +90,7 @@ function minify(context, source, options) {
     // after parse plugins
     if (options.beforeCompress) {
         debugOutput('beforeCompress', options, Date.now(),
-            runPlugins(ast, options, 'beforeCompress')
+            runPlugins(ast, options, options.beforeCompress)
         );
     }
 
@@ -102,7 +102,7 @@ function minify(context, source, options) {
     // after compress plugins
     if (options.afterCompress) {
         debugOutput('afterCompress', options, Date.now(),
-            runPlugins(compressResult, options, 'afterCompress')
+            runPlugins(compressResult, options, options.afterCompress)
         );
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,9 +88,9 @@ function minify(context, source, options) {
     );
 
     // after parse plugins
-    if (options.afterParse) {
-        debugOutput('afterParse', options, Date.now(),
-            runPlugins(ast, options, 'afterParse')
+    if (options.beforeCompress) {
+        debugOutput('beforeCompress', options, Date.now(),
+            runPlugins(ast, options, 'beforeCompress')
         );
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,18 @@ function buildCompressOptions(options) {
     return options;
 }
 
+function runPlugins(ast, options, plugin) {
+    var plugins = [];
+    if (typeof options[plugin] === 'object' && options[plugin].length) {
+        plugins = options[plugin];
+    } else if (typeof options[plugin] === 'function') {
+        plugins = [options[plugin]];
+    }
+    plugins.forEach(function(plugin) {
+        plugin(ast, options);
+    });
+}
+
 function minify(context, source, options) {
     options = options || {};
 
@@ -75,10 +87,24 @@ function minify(context, source, options) {
         })
     );
 
+    // after parse plugins
+    if (options.afterParse) {
+        debugOutput('afterParse', options, Date.now(),
+            runPlugins(ast, options, 'afterParse')
+        );
+    }
+
     // compress
     var compressResult = debugOutput('compress', options, Date.now(),
         compress(ast, buildCompressOptions(options))
     );
+
+    // after compress plugins
+    if (options.afterCompress) {
+        debugOutput('afterCompress', options, Date.now(),
+            runPlugins(compressResult, options, 'afterCompress')
+        );
+    }
 
     // translate
     if (options.sourceMap) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ function buildCompressOptions(options) {
 
 function runPlugins(ast, options, plugin) {
     var plugins = [];
-    if (typeof options[plugin] === 'object' && options[plugin].length) {
+    if (Array.isArray(options[plugin])) {
         plugins = options[plugin];
     } else if (typeof options[plugin] === 'function') {
         plugins = [options[plugin]];

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -3,10 +3,10 @@ var csso = require('../lib/index.js');
 var css = '.test{color:red;}@media foo{div{color:green}}';
 
 describe('plugins', function() {
-    it('calls afterParse when it is a function', function() {
+    it('calls beforeCompress when it is a function', function() {
         var called = true;
         var ast = csso.minify(css, {
-            afterParse: function (ast, options) {
+            beforeCompress: function (ast, options) {
                 assert(ast);
                 assert(options);
                 called = true;
@@ -17,7 +17,7 @@ describe('plugins', function() {
         assert(ast);
     });
 
-    it('calls afterParse when it is an array', function() {
+    it('calls beforeCompress when it is an array', function() {
         var called = [false, false];
         var pluginFactory = function (index) {
             return function callback(ast, options) {
@@ -27,7 +27,7 @@ describe('plugins', function() {
             };
         };
         var ast = csso.minify(css, {
-            afterParse: [pluginFactory(0), pluginFactory(1)]
+            beforeCompress: [pluginFactory(0), pluginFactory(1)]
         });
 
         assert(called[0]);

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,0 +1,71 @@
+var assert = require('assert');
+var csso = require('../lib/index.js');
+var css = '.test{color:red;}@media foo{div{color:green}}';
+
+describe('plugins', function() {
+    it('calls afterParse when it is a function', function() {
+        var called = true;
+        var ast = csso.minify(css, {
+            afterParse: function (ast, options) {
+                assert(ast);
+                assert(options);
+                called = true;
+            }
+        });
+
+        assert(called);
+        assert(ast);
+    });
+
+    it('calls afterParse when it is an array', function() {
+        var called = [false, false];
+        var pluginFactory = function (index) {
+            return function callback(ast, options) {
+                assert(ast);
+                assert(options);
+                called[index] = true;
+            };
+        };
+        var ast = csso.minify(css, {
+            afterParse: [pluginFactory(0), pluginFactory(1)]
+        });
+
+        assert(called[0]);
+        assert(called[1]);
+        assert(ast);
+    });
+
+    it('calls afterCompress when it is a function', function() {
+        var called = true;
+        var ast = csso.minify(css, {
+            afterCompress: function (compressResult, options) {
+                assert(compressResult);
+                assert(compressResult.ast);
+                assert(options);
+                called = true;
+            }
+        });
+
+        assert(called);
+        assert(ast);
+    });
+
+    it('calls afterCompress when it is an array', function() {
+        var called = [false, false];
+        var pluginFactory = function (index) {
+            return function callback(compressResult, options) {
+                assert(compressResult);
+                assert(compressResult.ast);
+                assert(options);
+                called[index] = true;
+            };
+        };
+        var ast = csso.minify(css, {
+            afterCompress: [pluginFactory(0), pluginFactory(1)]
+        });
+
+        assert(called[0]);
+        assert(called[1]);
+        assert(ast);
+    });
+});


### PR DESCRIPTION
When usign the api, it is sometime necessary to act on the ast object
between csso operations. Instead of having to deal with options and calls to
parse and compress, this change makes it easy to edit the ast object
after csso's parse (afterParse) and compress (afterCompress) operation.

This is especially good for task runner, which can accept those
parameters to be able to speed task execution.

---

The new for a plugin came in view when I was copy/pasting code from csso or grunt-csso into my grunt task.
This is the experiment I've made: https://gist.github.com/nitriques/9d3b05c530a54c3a885c6bf41b46dbae

It's a re-implementation of [purifycss](https://github.com/purifycss/purifycss) but using async streams and csso instead of sync reads and rework. As per my tests (I've tested it on 4 productions sites) it's 45 times faster. Purify css yields saving of ~5%, while my grunt task saves more that 45% using the same config. Those are big wins.

I can live with the current experiment I've made, but feel like it would live better as a csso plugin, hence the PR.

---

If you want, I can create the release for you. **All tests (both old and new) are passing.** I would also happy to send a PR to the grunt-csso project too.