### PR TITLE
Enforce LF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
This is needed on Windows with `autocrlf: true`, which is the default.