### PR TITLE
Simplify structure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/node_modules/
 /coverage/
+/dist/
+/node_modules/
 .idea

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-!.npmignore

--- a/dist/.npmignore
+++ b/dist/.npmignore
@@ -1,3 +1,0 @@
-*
-!csso.js
-!csso.min.js

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "dist/csso.js",
-    "dist/csso.min.js",
-    "lib"
+    "dist/csso.{js,map}",
+    "dist/csso.min.{js,map}",
+    "lib/**/*.js"
   ]
 }


### PR DESCRIPTION
Since we specify the files to include in package.json, we don't need the dist dir in the repo at all. Nor the .npmignore file.

Also, be more explicit with the files to include and add map files.