### PR TITLE
Fix rules inside at-rules not being added to `disallowDownMarkers`

### DIFF
--- a/lib/restructure/8-restructRuleset.js
+++ b/lib/restructure/8-restructRuleset.js
@@ -34,13 +34,27 @@ function processRule(node, item, list) {
     var allowMergeDown = true;
 
     list.prevUntil(item.prev, function(prev, prevItem) {
-        // skip non-ruleset node if safe
-        if (prev.type !== 'Rule') {
-            return utils.unsafeToSkipNode.call(selectors, prev);
+        var prevBlock = prev.block;
+        var prevType = prev.type;
+
+        if (prevType !== 'Rule') {
+            var unsafe = utils.unsafeToSkipNode.call(selectors, prev);
+
+            if (!unsafe && prevType === 'Atrule' && prevBlock) {
+                walk(prevBlock, {
+                    visit: 'Rule',
+                    enter: function(node) {
+                        node.prelude.children.each(function(data) {
+                            disallowDownMarkers[data.compareMarker] = true;
+                        });
+                    }
+                });
+            }
+
+            return unsafe;
         }
 
         var prevSelectors = prev.prelude.children;
-        var prevBlock = prev.block;
 
         if (node.pseudoSignature !== prev.pseudoSignature) {
             return true;

--- a/test/fixture/compress/restructure.merge/issue-358-1.css
+++ b/test/fixture/compress/restructure.merge/issue-358-1.css
@@ -1,0 +1,29 @@
+/*
+    Issue #358 at-rules should be considered when merging
+*/
+
+h1 {
+  font-size: 22px;
+}
+
+@media (min-width: 641px) {
+  h1 {
+    font-size: 35px;
+  }
+}
+
+h2 {
+  color: blue;
+  font-size: 20px;
+}
+
+@media (min-width: 641px) {
+  h2 {
+    font-size: 30px;
+  }
+}
+
+h3 {
+  color: blue;
+  font-size: 22px;
+}

--- a/test/fixture/compress/restructure.merge/issue-358-1.min.css
+++ b/test/fixture/compress/restructure.merge/issue-358-1.min.css
@@ -1,0 +1,1 @@
+h1{font-size:22px}@media (min-width:641px){h1{font-size:35px}}h2,h3{color:#00f;font-size:20px}@media (min-width:641px){h2{font-size:30px}}h3{font-size:22px}

--- a/test/fixture/compress/restructure.merge/issue-358-2.css
+++ b/test/fixture/compress/restructure.merge/issue-358-2.css
@@ -1,0 +1,22 @@
+/*
+    Issue #358 at-rules should be considered when merging
+*/
+
+.content .container {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (--viewport-l) {
+  .content .container {
+    flex-direction: row;
+  }
+}
+
+.row, .column {
+  display: flex;
+}
+
+.column {
+  flex-direction: column;
+}

--- a/test/fixture/compress/restructure.merge/issue-358-2.min.css
+++ b/test/fixture/compress/restructure.merge/issue-358-2.min.css
@@ -1,0 +1,1 @@
+.content .container{display:flex;flex-direction:column}@media (--viewport-l){.content .container{flex-direction:row}}.column,.row{display:flex}.column{flex-direction:column}


### PR DESCRIPTION
Attempts to address #358 by disabling the "merge down" optimization in a few more cases.

The test files here should clearly demonstrate incorrectly restructured output (when running against the current version of csso.)